### PR TITLE
feat(config): support browser launchOptions for Runner

### DIFF
--- a/packages/engine/src/runner.ts
+++ b/packages/engine/src/runner.ts
@@ -27,6 +27,7 @@ class Runner extends EventEmitter {
     browser: {
       type: 'chromium',
       headless: true,
+      launchOptions: {},
     },
     reporter: {
       alwaysShowTracing: false,
@@ -50,6 +51,7 @@ class Runner extends EventEmitter {
     if (!this.browserManager) {
       this.browserManager = new BrowserManger()
       await this.browserManager.launch(this.options.browser.type, {
+        ...this.options.browser.launchOptions,
         headless: this.options.browser.headless,
         slowMo: this.options.actionInterval,
       })

--- a/packages/engine/src/types/config.ts
+++ b/packages/engine/src/types/config.ts
@@ -1,4 +1,4 @@
-import { Page, BrowserContext, ElementHandle } from 'playwright'
+import { Page, BrowserContext, ElementHandle, LaunchOptions } from 'playwright'
 import { SelectorCfg } from '@idux/wetest-ai-selector'
 import { CaseManger } from '../caseManager'
 import { MockProxy } from '../mockProxy'
@@ -245,6 +245,13 @@ export type RunnerConfig = CommonConfig & {
      * @type {boolean}
      */
     headless: boolean
+
+    /**
+     * 浏览器启动参数
+     *
+     * @type {LaunchOptions}
+     */
+    launchOptions?: LaunchOptions
   }
 
   /**


### PR DESCRIPTION
添加浏览器启动参数，支持开发者自定义配置启动参数，比如需要浏览器支持跨域请求可以如下配置：

```js
//.wetest.js
{
    runner: {
        browser: {
            launchOptions: {
                args: ['--disable-web-security']
            }
        }
    }
}
```